### PR TITLE
Add autofocus prop to textbox and input.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,6 +31,7 @@
     "jsx-a11y/no-noninteractive-element-interactions": [0],
     "jsx-a11y/click-events-have-key-events": [0],
     "jsx-a11y/anchor-is-valid": [0],
+    "jsx-a11y/no-autofocus": [0],
     "no-nested-ternary": [0],
     "arrow-body-style": [0],
     "import/extensions": [0],

--- a/src/lib/components/input/input.js
+++ b/src/lib/components/input/input.js
@@ -13,6 +13,7 @@ class Input extends PureComponent {
     name: PropTypes.string.isRequired,
     value: PropTypes.string,
     type: PropTypes.string,
+    autoFocus: PropTypes.bool,
     onChangeFunction: PropTypes.func,
     // props from withValidation HOC
     renderValidationError: PropTypes.func,
@@ -51,6 +52,7 @@ class Input extends PureComponent {
       type,
       isValidationOk,
       renderValidationError,
+      autoFocus,
     } = this.props;
 
     return (
@@ -64,6 +66,7 @@ class Input extends PureComponent {
           required={required}
           onChange={this.handleChange(name)}
           disabled={disabled ? 'disabled' : ''}
+          autoFocus={autoFocus}
         />
         {renderValidationError()}
       </div>

--- a/src/lib/components/textbox/textbox.js
+++ b/src/lib/components/textbox/textbox.js
@@ -12,6 +12,7 @@ class TextBox extends PureComponent {
     required: PropTypes.bool,
     onChangeFunction: PropTypes.func,
     value: PropTypes.string,
+    autoFocus: PropTypes.bool,
     // props from withValidation HOC
     renderValidationError: PropTypes.func.isRequired,
     handleValidations: PropTypes.func.isRequired,
@@ -42,6 +43,7 @@ class TextBox extends PureComponent {
       className,
       value,
       theme,
+      autoFocus,
       isValidationOk,
       renderValidationError,
     } = this.props;
@@ -56,6 +58,7 @@ class TextBox extends PureComponent {
           name={name}
           value={value}
           required={required || false}
+          autoFocus={autoFocus}
         />
         {renderValidationError()}
       </div>


### PR DESCRIPTION
It's considered bad for a11y by some, but using this, when going to the first step in MR the viewport scrolls to the `First name` input field and focuses on that, which seems like a good idea from a UX perspective :) . I guess we can still use it with caution …