### PR TITLE
Feature: Remove "ERROR" from error messages.

### DIFF
--- a/lib/components/errorMessage.js
+++ b/lib/components/errorMessage.js
@@ -3262,7 +3262,7 @@ function (_React$PureComponent) {
         className: "".concat(styles.textContainer, " ").concat(message && styles.active)
       }, react.createElement("span", {
         className: classnames(styles.errorMessage, className)
-      }, "ERROR: ".concat(message))));
+      }, message)));
     }
   }]);
 

--- a/src/lib/components/errorMessage/__snapshots__/errorMessage.test.js.snap
+++ b/src/lib/components/errorMessage/__snapshots__/errorMessage.test.js.snap
@@ -10,7 +10,7 @@ exports[`ErrorMessage renders properly 1`] = `
     <span
       className="errorMessage"
     >
-      ERROR: Testing error message
+      Testing error message
     </span>
   </div>
 </div>

--- a/src/lib/components/errorMessage/errorMessage.js
+++ b/src/lib/components/errorMessage/errorMessage.js
@@ -21,7 +21,9 @@ class ErrorMessage extends React.PureComponent {
     return (
       <div className={classNames(styles[`theme-${theme}`], containerClassName)}>
         <div className={`${styles.textContainer} ${message && styles.active}`}>
-          <span className={classNames(styles.errorMessage, className)}>{`ERROR: ${message}`}</span>
+          <span className={classNames(styles.errorMessage, className)}>
+            {message}
+          </span>
         </div>
       </div>
     );


### PR DESCRIPTION
For less "computer says NO".

We can discuss if this makes sense for us, but to me, the capitalized **ERROR** in front of the error messages sounds like the computer is screaming at you.
Usually, the way we style errors it is (and should be!) obvious, that this is an error. 

See this PR for some screenshot examples: https://github.com/aimementoring/aime-portal/pull/535

https://www.youtube.com/watch?v=zUQgthIs7pM