### PR TITLE
Hotfix - Input Container

### DIFF
--- a/src/lib/components/input/input.module.scss
+++ b/src/lib/components/input/input.module.scss
@@ -5,8 +5,6 @@
 .inputWrapper {
   display: flex;
   flex-direction: column;
-  float: left;
-  width: 100%;
   margin-bottom: 0.5em;
 }
 


### PR DESCRIPTION
Taking width and float from inputWrapper class on input.module.scss