### PR TITLE
Fix Paragraph export

### DIFF
--- a/src/lib/components/index.js
+++ b/src/lib/components/index.js
@@ -28,3 +28,4 @@ export { default as CountryFlagSelector } from './countryFlag';
 export { default as ErrorMessage } from './errorMessage';
 export { default as HelpToolTip } from './helpToolTip';
 export { default as PhoneInput } from './phoneInput';
+export { default as Paragraph } from './paragraph';


### PR DESCRIPTION
Importing the `Paragraph` component like we import the other components didn't work, because we were missing this …