### PR TITLE
Setting 100% as max limit on ProgressBar progress

### DIFF
--- a/src/lib/components/progressBar/__snapshots__/progressBar.test.js.snap
+++ b/src/lib/components/progressBar/__snapshots__/progressBar.test.js.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ProgressBar renders properly even if the progress is > 100 1`] = `
+<div
+  className="theme-base"
+>
+  <div
+    className="progressBar"
+    style={
+      Object {
+        "height": "50px",
+      }
+    }
+  >
+    <div
+      className="progress"
+      style={
+        Object {
+          "fontSize": "undefinedpx",
+          "lineHeight": "50px",
+          "width": "100%",
+        }
+      }
+    >
+      100%
+    </div>
+  </div>
+</div>
+`;
+
 exports[`ProgressBar renders properly using all available props 1`] = `
 <div
   className="theme-base"

--- a/src/lib/components/progressBar/progressBar.js
+++ b/src/lib/components/progressBar/progressBar.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { componentPropTypes, defaultComponentPropTypes } from '../../utils/componentPropTypes';
+import {
+  componentPropTypes,
+  defaultComponentPropTypes,
+} from '../../utils/componentPropTypes';
 import styles from './progressBar.module.scss';
 
 const ProgressBar = ({
@@ -14,7 +17,7 @@ const ProgressBar = ({
   fontSize,
 }) => {
   const progressStyle = {
-    width: `${progress}%`,
+    width: `${Math.min(progress, 100)}%`,
     fontSize: `${fontSize}px`,
     lineHeight: `${height}px`,
   };
@@ -28,7 +31,7 @@ const ProgressBar = ({
     <div className={styles[`theme-${theme}`]}>
       <div className={styles.progressBar} style={progressBarStyle}>
         <div className={styles.progress} style={progressStyle}>
-          {displayNumber && `${progress}%`}
+          {displayNumber && `${Math.min(progress, 100)}%`}
         </div>
       </div>
     </div>

--- a/src/lib/components/progressBar/progressBar.module.scss
+++ b/src/lib/components/progressBar/progressBar.module.scss
@@ -13,6 +13,7 @@
 
 .progress {
   height: 100%;
+  max-width: 100%;
   display: flex;
   justify-content: flex-end;
   box-sizing: border-box;

--- a/src/lib/components/progressBar/progressBar.test.js
+++ b/src/lib/components/progressBar/progressBar.test.js
@@ -14,7 +14,16 @@ describe('ProgressBar', () => {
   });
 
   it('renders properly with just progress value and display number on true', () => {
-    const tree = renderer.create(<ProgressBar progress={40} displayNumber />).toJSON();
+    const tree = renderer
+      .create(<ProgressBar progress={40} displayNumber />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders properly even if the progress is > 100', () => {
+    const tree = renderer
+      .create(<ProgressBar progress={120} displayNumber />)
+      .toJSON();
     expect(tree).toMatchSnapshot();
   });
 


### PR DESCRIPTION
Hey @kbardi, 

In the spirit of trying to learn more and dive into uncomfortable React territory, I've been trying to set a `maxProgress` variable on the `ProgressBar` this morning. I think I need to stop trying... 

I was looking at the `utils/validation` files as an example of where we've set `maxCharacters` on an Input. Similarly, I am trying to set a `maxProgress const` of 100 because once the progress of anything reaches 100, we don't want it to go beyond that. Eg. Right now, in the portal, the users are seeing 113% once they've submitted everything.  Originally, I was editing portal files because I thought the progress percentage would be specific to whatever thing we're tracking (in this case completed steps of the application) but then I decided it was a blueprint thing because the progress of something should never go beyond 100. 

Some various attempts I tried (not all at once) but didn't push up because I was just getting error after error:

```
const ProgressBar = ({
  theme,
  progress,
  displayNumber,
  backgroundColor,
  barColor,
  color,
  height,
  fontSize,
  maxProgress,
})

const maxProgress = {
   maxLength: `100`,
 };

 {displayNumber && `${progress.maxProgress}%`}
```

Would love to talk to you about this one as I'd appreciate the learning opportunity :) 

In the meantime, I've set a very simple CSS rule on the progress styles so that visually if the progress goes beyond 100, you can still see the percentage number within the bar. 