### PR TITLE
Feat/component error styles

### DIFF
--- a/src/lib/components/checkbox/checkbox.js
+++ b/src/lib/components/checkbox/checkbox.js
@@ -62,6 +62,7 @@ class Checkbox extends PureComponent {
           } ${isValidationOk() && styles.error}`}
           onClick={this.handleFieldChange}
         >
+          {renderValidationError()}
           <input type="hidden" name={name} value="no" />
           <input
             id={customId}
@@ -79,7 +80,6 @@ class Checkbox extends PureComponent {
             {placeholder}
           </label>
         </div>
-        {renderValidationError()}
       </div>
     );
   }

--- a/src/lib/components/checkbox/checkbox.module.scss
+++ b/src/lib/components/checkbox/checkbox.module.scss
@@ -28,6 +28,14 @@
     }
   }
 
+  &.error {
+
+    ~ label {
+      margin: 0.8em 1.5em;
+      color: $black;
+    }
+  }
+
   &:not(:checked) {
     ~ label:after {
       @include themify() {
@@ -105,13 +113,20 @@
   }
 }
 
-.error {
-  @include themify() {
-    color: themed('fieldColorError');
-  }
-}
-.errorMessage {
-  @include themify() {
-    color: themed('fieldColorError');
+.customCheckbox.error {
+  position: relative;
+  border: 2px solid $error-color;
+  border-radius: 3px;
+  padding: 0.5em;
+  
+  // this should be targetted with .errorMessage however
+  // .errorMessage is in withValidations component
+  // so won't work here because css modules
+  span span {
+    position: absolute;
+    top: -1em;
+    left: 1em;
+    background: $white;
+    padding: 0.5em;
   }
 }

--- a/src/lib/styles/themes/imaginationRainbowTheme/imaginationRainbowTheme.module.scss
+++ b/src/lib/styles/themes/imaginationRainbowTheme/imaginationRainbowTheme.module.scss
@@ -32,7 +32,7 @@ $imaginationRainbowTheme: (
   fieldBorderFocused: $purple,
   fieldColorError: $error-color,
   errorColor: $error-color,
-  errorFont: $sans-serif-font,
+  errorFont: $serif-font-bold,
   fieldPlaceholderColor: $grey-40,
   fieldPlaceholderFontSize: 0.9rem,
   fieldPlaceholderFontWeight: 400,

--- a/src/lib/styles/themes/purplePlainTheme/purplePlainTheme.module.scss
+++ b/src/lib/styles/themes/purplePlainTheme/purplePlainTheme.module.scss
@@ -31,7 +31,7 @@ $purplePlainTheme: (
   fieldBorderFocused: $purple,
   fieldColorError: $error-color,
   errorColor: $error-color,
-  errorFont: $sans-serif-font,
+  errorFont: $serif-font-bold,
   fieldPlaceholderColor: $grey-40,
   fieldPlaceholderFontSize: 0.9rem,
   fieldPlaceholderFontWeight: 400,

--- a/src/lib/utils/hocs/withValidation.module.scss
+++ b/src/lib/utils/hocs/withValidation.module.scss
@@ -3,7 +3,6 @@
 
 .errorMessage {
   display: block;
-  padding-top: 0.5em;
   font-size: .8rem;
   color: $error-color;
   font-family: $serif-font-bold;


### PR DESCRIPTION
Hey guys, 

Today I designed these new checkbox error styles that you can see in Figma. The one we're going with (until @charliemckenzie confirms) is this one:

<img width="762" alt="Screen Shot 2020-03-05 at 7 28 19 pm" src="https://user-images.githubusercontent.com/39749772/75962254-8ba5b200-5f17-11ea-8801-69c054d89de5.png">

Then I worked on coding it into blueprint. However, I ran into some issues with CSS modules and the fact that our validation messages are in a separate component to the error container. You'll see i've left a comment in `checkbox.module.scss` about it on line `122`. @kbardi would love to talk to you about this in the morn 'cause I'm not sure that targeting it through `span span` is the right way to go about it. For now, it works though so we could do a merge and release if @davidpaley wants this included for MR deployment today. (I think we should merge and then work to improve it asap). 

The error should look like this in context: _(Slightly diff to the design for now but again, will improve later)._

<img width="1680" alt="Screen Shot 2020-03-05 at 7 24 18 pm" src="https://user-images.githubusercontent.com/39749772/75962438-e17a5a00-5f17-11ea-9779-999100255c4d.png">
