### PR TITLE
Fix: Let people empty date fields.

### DIFF
--- a/src/lib/components/input/utils.ignore.js
+++ b/src/lib/components/input/utils.ignore.js
@@ -6,7 +6,6 @@ export const handleInputChange = (
 ) => {
   const { type, checked } = event.target;
   const value = type === 'checkbox' ? checked : event.target.value;
-  if (type === 'date' && !value) return;
   const isWrongValidation = handleValidations(value);
   onChangeFunction(name, value, isWrongValidation);
 };


### PR DESCRIPTION
I think every one should be able to empty a date field … and I need this for what I do in Portal right now.

Would love to know what was the thinking behind this, it really confused me. :)