### PR TITLE
Adds error example, and fixes classes

### DIFF
--- a/src/lib/components/checkbox/checkbox.js
+++ b/src/lib/components/checkbox/checkbox.js
@@ -62,7 +62,7 @@ class Checkbox extends PureComponent {
           } ${isValidationOk() && styles.error}`}
           onClick={this.handleFieldChange}
         >
-          {renderValidationError()}
+          {renderValidationError(styles.errorMessage)}
           <input type="hidden" name={name} value="no" />
           <input
             id={customId}

--- a/src/lib/components/checkbox/checkbox.md
+++ b/src/lib/components/checkbox/checkbox.md
@@ -36,3 +36,23 @@ function updateValue(name, value) {
   theme="base"
 />;
 ```
+
+```js
+initialState = {
+  checkbox: null,
+};
+
+function updateValue(name, value) {
+  setState({ [name]: value });
+}
+
+<Checkbox
+  elementClassName="classname"
+  onChangeFunction={updateValue}
+  placeholder="Accept terms and conditions"
+  name="checkbox"
+  customId="checkbox"
+  value={state.checkbox}
+  validationMessage="required"
+/>;
+```

--- a/src/lib/components/checkbox/checkbox.module.scss
+++ b/src/lib/components/checkbox/checkbox.module.scss
@@ -12,7 +12,7 @@
 
   ~ label {
     @include themify() {
-      font-family: themed('bodyFontFamily');  
+      font-family: themed('bodyFontFamily');
     }
     position: relative;
     cursor: pointer;
@@ -118,11 +118,8 @@
   border: 2px solid $error-color;
   border-radius: 3px;
   padding: 0.5em;
-  
-  // this should be targetted with .errorMessage however
-  // .errorMessage is in withValidations component
-  // so won't work here because css modules
-  span span {
+
+  .errorMessage span {
     position: absolute;
     top: -1em;
     left: 1em;

--- a/src/lib/utils/hocs/withValidation.js
+++ b/src/lib/utils/hocs/withValidation.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { checkValidations } from '../validation';
 import styles from './withValidation.module.scss';
 
@@ -53,9 +54,9 @@ export default function withValidation(WrappedComponent) {
 
     isValidationOk = () => !!this.state.validationMessage;
 
-    renderValidationError = () =>
+    renderValidationError = (customStyle = '') =>
       this.isValidationOk() && (
-        <span className={styles[`theme-${this.props.theme}`]}>
+        <span className={classNames(styles[`theme-${this.props.theme}`], customStyle)}>
           <span className={styles.errorMessage}>{this.getValidationMessage()}</span>
         </span>
       );


### PR DESCRIPTION
Adds a workaround to pass styles to a different component.
The main concept of css modules is that each component with their styles are independent, so the only way we have to change it is sending a prop to the component.
The great idea behind it is that you know when you make changes outside the component, you never have impact in other places where you use the component...this is awesome, but the thing is sometimes it is not easy to change some styles...for that reason we need a property, and for that reason in every component in blueprint we have a prop called elementClassName or containerClassName, where we allow to edit styles in the component.