### PR TITLE
Fix: Do not use fixed height for T&C children.

### DIFF
--- a/src/lib/components/termsAndConditions/__snapshots__/termsAndConditions.test.js.snap
+++ b/src/lib/components/termsAndConditions/__snapshots__/termsAndConditions.test.js.snap
@@ -35,7 +35,6 @@ exports[`TermsAndConditions renders properly with all props used 1`] = `
   >
     <div
       className="textContainer "
-      style={Object {}}
     >
       <strong>
         Lorem ipsum dolor sit amet
@@ -63,11 +62,6 @@ exports[`TermsAndConditions renders properly with all props used 2`] = `
   >
     <div
       className="textContainer "
-      style={
-        Object {
-          "height": "150px",
-        }
-      }
     >
       <strong>
         Lorem ipsum dolor sit amet
@@ -183,7 +177,6 @@ exports[`TermsAndConditions renders properly with paragraph props 1`] = `
   >
     <div
       className="textContainer "
-      style={Object {}}
     >
       <div
         className="theme-base"

--- a/src/lib/components/termsAndConditions/termsAndConditions.js
+++ b/src/lib/components/termsAndConditions/termsAndConditions.js
@@ -48,12 +48,12 @@ const TermsAndConditions = ({
           </div>
         )}
         {children && (
-          <div className={`${styles.textContainer} ${className}`} style={containerStyle}>
+          <div className={`${styles.textContainer} ${className}`}>
             {children}
           </div>
         )}
         {paragraph && (
-          <div className={`${styles.textContainer} ${className}`} style={containerStyle}>
+          <div className={`${styles.textContainer} ${className}`}>
             {typeof paragraph === 'string' ? (
               <Paragraph text={paragraph} />
             ) : (


### PR DESCRIPTION
Somehow we decided that the fixed width we pass the component would also be applied to the text container … I think it maybe was just copy + paste because it doesn't really make sense …?

Needed for this PR: https://github.com/aimementoring/aime-portal/pull/881