### PR TITLE
Cleaning Titles CSS & utilising composes

### DIFF
--- a/src/lib/components/animatedCircleText/__snapshots__/animatedCircleText.test.js.snap
+++ b/src/lib/components/animatedCircleText/__snapshots__/animatedCircleText.test.js.snap
@@ -23,7 +23,7 @@ exports[`AnimatedCircleText renders properly in reverse mode 1`] = `
         onClick={[Function]}
       >
         <h3
-          className="h3Title alignCenter"
+          className="h3Title alignLeft"
         >
           <span
             className=""
@@ -271,7 +271,7 @@ exports[`AnimatedCircleText renders properly in standard mode 1`] = `
         onClick={[Function]}
       >
         <h3
-          className="h3Title alignCenter"
+          className="h3Title alignLeft"
         >
           <span
             className=""

--- a/src/lib/components/title/__snapshots__/title.test.js.snap
+++ b/src/lib/components/title/__snapshots__/title.test.js.snap
@@ -6,7 +6,7 @@ exports[`Title is backwards compatible (text passed as prop) 1`] = `
   onClick={[Function]}
 >
   <h1
-    className="h1Title alignCenter"
+    className="h1Title alignLeft"
   >
     h1 default title
   </h1>
@@ -19,7 +19,7 @@ exports[`Title renders properly 1`] = `
   onClick={[Function]}
 >
   <h1
-    className="h1Title alignCenter"
+    className="h1Title alignLeft"
   >
     h1 default title
   </h1>

--- a/src/lib/components/title/title.js
+++ b/src/lib/components/title/title.js
@@ -86,18 +86,15 @@ Title.propTypes = {
     'h4Title',
     'h5Title',
     'headingLockup',
-    'headingLockupCenter',
-    'headingLockupRight',
-    'headingLockupLeft',
   ]),
   children: PropTypes.node,
 };
 
 Title.defaultProps = {
   ...defaultComponentPropTypes,
-  onClick: () => {},
+  onClick: () => { },
   type: 'h1Title',
-  align: 'center',
+  align: 'left',
 };
 
 export default Title;

--- a/src/lib/components/title/title.module.scss
+++ b/src/lib/components/title/title.module.scss
@@ -1,118 +1,98 @@
 @import '../../styles/variables/variables.module.scss';
 @import '../../styles/themes/themes.module.scss';
 
+.alignLeft {
+  text-align: left;
+}
 
 .alignCenter {
   text-align: center;
-}
-
-.alignLeft  {
-  text-align: left;
 }
 
 .alignRight {
   text-align: right;
 }
 
-.h1Title {
+.featureTitleAttributes {
   @include themify() {
     font-family: themed('featureFont');
   }
-  font-size: 8rem;
-  line-height: 0.8em;
   font-weight: 100;
   font-style: normal;
+}
+
+.primaryTitleAttributes {
+  @include themify() {
+    font-family: themed('primaryFontBold');
+  }
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  font-weight: 900;
+  font-style: normal;
+}
+
+.h1Title {
+  composes: featureTitleAttributes;
+  font-size: 8rem;
+  line-height: 0.8em;
 }
 
 .h2Title {
-  @include themify() {
-    font-family: themed('featureFont');
-  }
+  composes: featureTitleAttributes;
   font-size: 6rem;
   line-height: 0.8em;
-  font-weight: 100;
-  font-style: normal;
 }
 
 .h3Title {
-  @include themify() {
-    font-family: themed('featureFont');
-  }
+  composes: featureTitleAttributes;
   font-size: 2.5rem;
   line-height: 1em;
-  font-weight: 100;
-  font-style: normal;
 }
 
 .h4Title {
-  @include themify() {
-    font-family: themed('primaryFontBold');
-  }
+  composes: primaryTitleAttributes;
   font-size: 1.5rem;
   line-height: 1.3em;
-  text-transform: uppercase;
-  letter-spacing: -0.01em;
-  font-weight: 900;
-  font-style: normal;
 }
 
 .h5Title {
-  @include themify() {
-    font-family: themed('primaryFontBold');
-  }
+  composes: primaryTitleAttributes;
   font-size: 1rem;
   line-height: 1.5em;
-  text-transform: uppercase;
-  letter-spacing: -0.01em;
-  font-weight: 900;
-  font-style: normal;
 }
 
 .headingLockup {
+  @include themify() {
+    font-family: themed('featureFont');
+  }
   position: relative;
   transform: rotate(0);
   font-size: 1.5rem;
   line-height: 1.4em;
   font-style: normal;
   font-weight: normal;
-  
-  @include themify() {
-    font-family: themed('featureFont');
-  }
-  
+
   @media all and(min-width: $md) {
     font-size: 2.5rem;
   }
-  
+
   strong {
-    font-weight: normal;
     position: relative;
     transform: rotate(-7deg);
+    display: block;
+    clear: both;
+    top: -0.3em;
     font-size: 3rem;
     line-height: 1em;
-    clear: both;
-    display: block;
-    top: -0.3em;
-    left: -0.5em;
+    font-weight: normal;
 
-    
     @media all and(min-width: $md) {
       font-size: 5rem;
     }
   }
-  
-  &.alignCenter strong {
-    top: -0.2em;
-    left: 0em;
-  }
-  
-  &.alignLeft strong {
-    top: -0.5em;
-    left: 0em;
-  }
-  
+
   &.alignRight strong {
-    top: 0.1em;
-    left: 0;
+    transform: rotate(-4deg);
+    top: -0.15em;
   }
 }


### PR DESCRIPTION
Hey @rin and @kbardi I've just slightly updated the styles on the Titles component to make use of `composes` and remove the extra CSS we no longer need for the realigned types. 

I also removed the extra `type` propTypes that I don't think we're using now that we're using the `align` propType instead. 

AND set the default `h1Title` to be aligned `left` by default. I think that makes more sense as that's the default behaviour we would expect when adding in the regular title. 